### PR TITLE
Prevent generated id override

### DIFF
--- a/src/Handler/CreateAndFetch.php
+++ b/src/Handler/CreateAndFetch.php
@@ -74,7 +74,7 @@ final class CreateAndFetch implements RequestHandlerInterface
     {
         $request = $request->withAttribute(
             IdentifierGenerator::class,
-            $this->identifierGenerator->generate()
+            $request->getAttribute(IdentifierGenerator::class, $this->identifierGenerator->generate())
         );
 
         $input = new HttpRequest($request);

--- a/src/Handler/CreateOnly.php
+++ b/src/Handler/CreateOnly.php
@@ -70,7 +70,7 @@ final class CreateOnly implements RequestHandlerInterface
     {
         $request = $request->withAttribute(
             IdentifierGenerator::class,
-            $this->identifierGenerator->generate()
+            $request->getAttribute(IdentifierGenerator::class, $this->identifierGenerator->generate())
         );
 
         $this->action->execute(new HttpRequest($request));

--- a/tests/Handler/CreateAndFetchTest.php
+++ b/tests/Handler/CreateAndFetchTest.php
@@ -15,6 +15,7 @@ use Lcobucci\ContentNegotiation\UnformattedResponse;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\ResponseFactory;
 use Zend\Diactoros\ServerRequest;
 
@@ -65,15 +66,6 @@ final class CreateAndFetchTest extends TestCase
      */
     public function handleShouldExecuteTheCommandAndReturnAnEmptyResponse(): void
     {
-        $handler = new CreateAndFetch(
-            new ExecuteCommand($this->bus, $this->creator, 'command'),
-            new ExecuteQuery($this->bus, $this->creator, 'query'),
-            new ResponseFactory(),
-            'info',
-            $this->uriGenerator,
-            $this->idGenerator
-        );
-
         $request = new ServerRequest();
         $command = (object) ['a' => 'b'];
         $query   = (object) ['c' => 'd'];
@@ -96,12 +88,68 @@ final class CreateAndFetchTest extends TestCase
                            ->willReturn('/testing/1');
 
         /** @var ResponseInterface|UnformattedResponse $response */
-        $response = $handler->handle($request);
+        $response = $this->handleRequest($request);
 
         self::assertInstanceOf(UnformattedResponse::class, $response);
         self::assertSame(StatusCodeInterface::STATUS_CREATED, $response->getStatusCode());
         self::assertSame('/testing/1', $response->getHeaderLine('Location'));
         self::assertSame([ExecuteQuery::class => 'query'], $response->getAttributes());
         self::assertSame('result', $response->getUnformattedContent());
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct()
+     * @covers ::handle()
+     * @covers ::generateResponse()
+     *
+     * @uses \Chimera\Routing\HttpRequest
+     */
+    public function handleShouldPreserveTheRequestGeneratedIdIfAlreadyPresent(): void
+    {
+        $request = (new ServerRequest())->withAttribute(IdentifierGenerator::class, 2);
+        $command = (object) ['a' => 'b'];
+        $query   = (object) ['c' => 'd'];
+
+        $this->creator->expects(self::exactly(2))
+                      ->method('create')
+                      ->willReturn($command, $query);
+
+        $this->bus->expects(self::exactly(2))
+                  ->method('handle')
+                  ->withConsecutive([$command], [$query])
+                  ->willReturn(null, 'result');
+
+        $this->idGenerator->method('generate')
+                          ->willReturn(1);
+
+        $this->uriGenerator->expects(self::once())
+                           ->method('generateRelativePath')
+                           ->with($request, 'info')
+                           ->willReturn('/testing/2');
+
+        /** @var ResponseInterface|UnformattedResponse $response */
+        $response = $this->handleRequest($request);
+
+        self::assertInstanceOf(UnformattedResponse::class, $response);
+        self::assertSame(StatusCodeInterface::STATUS_CREATED, $response->getStatusCode());
+        self::assertSame('/testing/2', $response->getHeaderLine('Location'));
+        self::assertSame([ExecuteQuery::class => 'query'], $response->getAttributes());
+        self::assertSame('result', $response->getUnformattedContent());
+    }
+
+    private function handleRequest(ServerRequestInterface $request): ResponseInterface
+    {
+        $handler = new CreateAndFetch(
+            new ExecuteCommand($this->bus, $this->creator, 'command'),
+            new ExecuteQuery($this->bus, $this->creator, 'query'),
+            new ResponseFactory(),
+            'info',
+            $this->uriGenerator,
+            $this->idGenerator
+        );
+
+        return $handler->handle($request);
     }
 }


### PR DESCRIPTION
@lcobucci This is a tentative first step in making Chimera work with both client side and server side generated Ids.

The idea of this PR is to allow users of chimera to, via an HTTP middleware, add themselves an attribute to the ServerRequest to specify the ID they would like to have (where that comes from we do not care).

In this case, the only thing Chimera is supposed to do is respect their decision and process the request normally, without overriding the ID the user set.

This is the first step in the sense that this will already allow an user of chimera to set its own id and have the location header working correctly.

I would like some early feedback regarding what I am doing and hear your suggestions.

Fixes #20 